### PR TITLE
Dark / more modern scrollbar

### DIFF
--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -45,3 +45,46 @@
     }
   }
 }
+
+// https://css-tricks.com/custom-scrollbars-in-webkit/
+
+::-webkit-scrollbar, ::-webkit-scrollbar-button, ::-webkit-scrollbar-corner {
+  height: 12px;
+  width: 12px;
+  background: #000;
+}
+
+/*
+::-webkit-scrollbar-button:vertical {
+  height: 6px;
+}
+
+::-webkit-scrollbar-button:horizontal {
+  width: 6px;
+}
+*/
+
+::-webkit-scrollbar-thumb {
+  -webkit-border-radius: 1ex;
+  -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
+}
+
+::-webkit-scrollbar-thumb, ::-webkit-scrollbar-button {
+  background: #333;
+}
+
+::-webkit-scrollbar-thumb:hover, ::-webkit-scrollbar-button:hover {
+  background: #444;
+}
+
+::-webkit-scrollbar-thumb:active, ::-webkit-scrollbar-button:active {
+  background: #666;
+}
+
+::-webkit-scrollbar-track:hover {
+  background: #111;
+}
+
+::-webkit-scrollbar-track:active {
+  background: #222;
+}


### PR DESCRIPTION
In dark mode, scrollbar looks out of place (and even in light mode it looks too old-school on Win10).

Here's what I did in my "dark" fork to make it look nicer (thinner, round, matching the window colors).
However, for some reason it's not applied when you change the theme after the app's initial load. So I've added this there and changed the default mode in js files (I wanted to make it default anyway).

And i'm not a web/JS developer to investigate it. So you might need to tweak the css to make it work with changing theme.

<details>
<summary>Screenshot</summary>

![screenshot](https://user-images.githubusercontent.com/3897975/111381869-58176f00-86b7-11eb-81ad-114335faa35b.png)
</details>