### PR TITLE
save a nice format to file

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -88,7 +88,7 @@ if (isDevelopment) {
 
 //===================================================================================  ipc calls
 ipc.on('save-file', function(event, {filePath, worldEntries}) {
-  let content = JSON.stringify(worldEntries);
+  let content = JSON.stringify(worldEntries, null, "  ");
   fs.writeFile(filePath, content, function(err){
     if(err){
       return console.log(err);


### PR DESCRIPTION
Adds the indent parameter in `JSON.stringify` so that the output file is nicer and more readable. It uses a 2-space indent to be consistent with the styling in your code.